### PR TITLE
remove deprecated sentence in README

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,14 +4,10 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
 
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
 
 jobs:
   shellcheck:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Java, either on the system, or better, via some asdf-java
 Plugin:
 
 ```shell
-asdf plugin djinni
+asdf plugin add djinni
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ Java, either on the system, or better, via some asdf-java
 Plugin:
 
 ```shell
-asdf plugin add djinni https://github.com/cross-language-cpp/asdf-djinni.git
-```
-
-or, once this plugin will be in the [asdf-plugin repo](https://github.com/asdf-vm/asdf-plugins)
-
-```shell
 asdf plugin djinni
 ```
 


### PR DESCRIPTION
AFAIK the plugin is registered in the registry and therefore the instructions on how to add it manually are not required any more?